### PR TITLE
FIX: Changing pixel size doesn't change color

### DIFF
--- a/app.js
+++ b/app.js
@@ -99,7 +99,7 @@ function redrawBoard() {
     for (var j = 0; j < width; j++) {
       var box = document.createElement('div');
       box.tabindex = 1;
-      box.className = 'box black';
+      box.className = 'box ' + COLORS[activeColor].name;
       box.style.width = box.style.height = size;
       container.appendChild(box);
     }
@@ -174,7 +174,6 @@ function updateDecay() {
 
 function updatePixelSize() {
   redrawBoard();
-  focusBoard();
   updateLocalStorage();
   pixelSizeDisplay.textContent = pixelSize.value + 'px';
 }


### PR DESCRIPTION
Changing the pixel size made the color change to black every time. I fixed it by using `activeColor`. Also, the `focusBoard()` call was already there inside `redrawBoard`, so I removed the extraneous call inside `updatePixelSize()`.
:tada: